### PR TITLE
[improvement] Return early if pass in config through env var

### DIFF
--- a/DiffFormatter/App/Info.plist
+++ b/DiffFormatter/App/Info.plist
@@ -9,6 +9,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.0.10</string>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 </dict>
 </plist>

--- a/DiffFormatter/Configuration/Configurator.swift
+++ b/DiffFormatter/Configuration/Configurator.swift
@@ -21,6 +21,14 @@ struct Configurator {
         // Start with default configuration
         self.configuration = .default(currentDirectory: fileManager.currentDirectoryPath)
 
+        // Return early if env var config is passed in
+        if let value = processInfo.environment["DIFF_FORMATTER_CONFIG"], !value.isEmpty {
+            if let config = configuration(forPath: value), !config.isBlank {
+                configuration.update(with: config)
+                return
+            }
+        }
+
         guard case let home = fileManager.homeDirectoryForCurrentUser.path, !home.isEmpty else {
             return
         }
@@ -43,13 +51,6 @@ struct Configurator {
                 configuration.update(with: config)
             }
             break
-        }
-
-        // Load config overrides from custom path if env var included
-        if let value = processInfo.environment["DIFF_FORMATTER_CONFIG"], !value.isEmpty {
-            if let config = configuration(forPath: value), !config.isBlank {
-                configuration.update(with: config)
-            }
         }
     }
 


### PR DESCRIPTION
If config is passed through env var, this ensures that config will be used without project and home configs obscuring this config