### PR TITLE
[cleanup] No need for Scripts dir at this point

### DIFF
--- a/Scripts/update-build-number
+++ b/Scripts/update-build-number
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-APP_NAME=DiffFormatter
-BUILD_NUMBER_FILE=$(dirname $0)/../Sources/$APP_NAME/App/BuildNumber.swift
-
-## Update build number file unless told not to
-if [ -z $NO_UPDATE_BUILD_NUMBER ]; then
-    echo "let appBuildNumber: Int = $(git rev-list @ --count)" > $BUILD_NUMBER_FILE
-fi


### PR DESCRIPTION
Scripts have been moved into `Makefile` or eliminated. This removes the `Scripts/` dir